### PR TITLE
citrix_hypervisor: Add missing $schema property

### DIFF
--- a/citrix_hypervisor.json
+++ b/citrix_hypervisor.json
@@ -1,5 +1,6 @@
 #! /usr/bin/env lnav -i
 {
+  "$schema": "https://lnav.org/schemas/format-v1.schema.json",
   "xensource_log" : {
     "title" : "xensource.log",
     "description" : "XenServer logs stored in /var/log/xensource.log",


### PR DESCRIPTION
lnav 0.11.2 complains that the format file is missing the "$schema" property:

```
  $ lnav -W var/log/xensource.log
  ⚠ warning: format file is missing “$schema” property
   --> /home/jmerino/.lnav/formats/installed/citrix_hypervisor.json
   =   note: the schema specifies the supported format version and can be used with editors to automatically validate the file
   =   help: add the following property to the top-level JSON object:
               "$schema": "https://lnav.org/schemas/format-v1.schema.json",
```