### PR TITLE
Recognize hostnames in xenrt.log and improve CI test

### DIFF
--- a/citrix_hypervisor.json
+++ b/citrix_hypervisor.json
@@ -198,7 +198,7 @@
     "file-pattern" : "xenrt.log",
     "regex" : {
       "xenrt_log" : {
-        "pattern" : "^(?<threadid>\\[Thread-[^\\[\\]]*\\] )?\\[(?<level>[^\\]\\[]+)\\] \\[(?<timestamp>\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} UTC)\\] (?<body>.*)",
+        "pattern" : "^(?<threadid>\\[[^\\[\\]]*\\] )?(?<hostname>\\[[a-z0-9\\-]+\\] )?\\[(?<level>[^\\]\\[]+)\\] \\[(?<timestamp>\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} UTC)\\] (?<body>.*)",
         "module-format" : false
       }
     },
@@ -218,9 +218,19 @@
       "debug" : "VERBOSE|HTCHECK"
     },
     "multiline" : true,
+    "value" : {
+      "hostname" : {
+        "kind" : "string",
+        "identifier" : true
+      }
+    },
     "sample" : [
       {
         "line" : "[VERBOSE] [2018-11-17 16:54:02 UTC] Setting MainThread TEC to TEC:TCCBTNBDBlockVerify",
+        "level" : "debug"
+      },
+      {
+        "line" : "[HWorker00] [host5-05] [VERBOSE] [2024-11-07 14:28:33 UTC] Local command: ls",
         "level" : "debug"
       },
       {

--- a/citrix_hypervisor.json
+++ b/citrix_hypervisor.json
@@ -198,7 +198,7 @@
     "file-pattern" : "xenrt.log",
     "regex" : {
       "xenrt_log" : {
-        "pattern" : "^(?<threadid>\\[Thread-[^\\[\\]]*\\] )?\\[(?<level>[^\\]\\[]+)\\] \\[(?<timestamp>[^\\[\\]]+)\\] (?<body>.*)",
+        "pattern" : "^(?<threadid>\\[Thread-[^\\[\\]]*\\] )?\\[(?<level>[^\\]\\[]+)\\] \\[(?<timestamp>\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} UTC)\\] (?<body>.*)",
         "module-format" : false
       }
     },

--- a/test.sh
+++ b/test.sh
@@ -4,10 +4,13 @@
 set -uex
 
 # If we have the latest lnav version, check that there are no warnings
-[[ "$(lnav -V)" == lnav\ 0.10.* ]] && \
-  (! (lnav -C |& grep "^warning:"))
+CURR_VERSION=$(lnav -V | sed -e 's/lnav //')
 
-lnav -C
+if [[ $(echo -e "0.10.0\n$CURR_VERSION" | sort -V | head -n1) != "$CURR_VERSION" ]]; then
+  (! (lnav -C |& grep "^warning:"))
+else
+  lnav -C
+fi
 
 # Test that the different fields are extracted correctly
 


### PR DESCRIPTION
For `xenrt.log`, improve the pattern to detect hostnames as well.

While we are at it, improve the logic of `test.sh` to cope with newer `lnav`.